### PR TITLE
Set correct scheme if https module is used.

### DIFF
--- a/builtin/https.js
+++ b/builtin/https.js
@@ -1,1 +1,13 @@
-module.exports = require('http');
+var http = require('http');
+
+var https = module.exports;
+
+for (var key in http) {
+    if (http.hasOwnProperty(key)) https[key] = http[key];
+};
+
+https.request = function (params, cb) {
+    if (!params) params = {};
+    params.scheme = 'https';
+    return http.request.call(this, params, cb);
+}


### PR DESCRIPTION
Currently `http-browserify` lets you specify the `scheme` option to switch to https but no nodejs module uses this parameter. It should be used automatically when https module is required.
