### PR TITLE
Include file path in error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ function load_shims(paths, cb) {
                 var info = JSON.parse(data);
             }
             catch (err) {
+                err.message = pkg_path + ' : ' + err.message
                 return cb(err);
             }
 


### PR DESCRIPTION
Currently, if there's a syntax error in the package.json, browserify quits with a fairly cryptic message:

``` cpp
> browserify index.js
SyntaxError: Unexpected token }
```

After some time I figured out this wasn't a syntax error in my source code, rather it was in the package.json and the error was coming out of `node-browser-resolve`. Would be nice if `node-browser-resolve` exposed the file name causing the parse error if it comes across one.

Errors now look like:

`/…/…/project/package.json : Unexpected token }`
