### PR TITLE
Update resolve to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Roman Shtylman <shtylman@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "resolve": "0.4.2"
+    "resolve": "0.5.1"
   },
   "devDependencies": {
     "mocha": "1.12.0"


### PR DESCRIPTION
This adds a fix for using `resolve` on windows network shares (essential for using browserify in windows azure).
