### PR TITLE
Allow Windows nodejs to search <drive>:\node_modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,8 @@ function nodeModulesPaths (start, cb) {
     var dirs = [];
     for (var i = parts.length - 1; i >= 0; i--) {
         if (parts[i] === 'node_modules') continue;
-        var dir = path.join(
-            path.join.apply(path, parts.slice(0, i + 1)),
-            'node_modules'
+        var dir = path.join.apply(
+            path, parts.slice(0, i + 1).concat(["node_modules"])
         );
         if (!parts[0].match(/([A-Za-z]:)/)) {
             dir = '/' + dir;


### PR DESCRIPTION
Currently, there is a bug where the nodeModulesPaths function will not properly return the node_modules directory in the root of the disk.  This is due to the following statement being true:

```
path.join.apply(path, ["c:", "dev", "workspace"].slice(0, 1)) === "c:."
```

This resulted in the returned path being "c:node_modules", which is invalid.

This code change fixes the bug by doing the path.join in one statement, including "node_modules" as part of the arguments.
