### PR TITLE
Implement synchronous api

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,58 @@ function nodeModulesPaths (start, cb) {
     return dirs;
 }
 
+function find_shims_in_package(pkgJson, cur_path, shims) {
+    try {
+        var info = JSON.parse(pkgJson);
+    }
+    catch (err) {
+        err.message = pkg_path + ' : ' + err.message
+        throw err;
+    }
+
+    // support legacy browserify field for easier migration from legacy
+    // many packages used this field historically
+    if (typeof info.browserify === 'string' && !info.browser) {
+        info.browser = info.browserify;
+    }
+
+    // no replacements, skip shims
+    if (!info.browser) {
+        return;
+    }
+
+    // if browser field is a string
+    // then it just replaces the main entry point
+    if (typeof info.browser === 'string') {
+        var key = path.resolve(cur_path, info.main || 'index.js');
+        shims[key] = path.resolve(cur_path, info.browser);
+        return;
+    }
+
+    // http://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders
+    Object.keys(info.browser).forEach(function(key) {
+        if (info.browser[key] === false) {
+            return shims[key] = __dirname + '/empty.js';
+        }
+
+        var val = info.browser[key];
+
+        // if target is a relative path, then resolve
+        // otherwise we assume target is a module
+        if (val[0] === '.') {
+            val = path.resolve(cur_path, val);
+        }
+
+        // if does not begin with / ../ or ./ then it is a module
+        if (key[0] !== '/' && key[0] !== '.') {
+            return shims[key] = val;
+        }
+
+        key = path.resolve(cur_path, key);
+        shims[key] = val;
+    });
+}
+
 // paths is mutated
 // load shims from first package.json file found
 function load_shims(paths, cb) {
@@ -50,60 +102,79 @@ function load_shims(paths, cb) {
 
                 return cb(err);
             }
-
             try {
-                var info = JSON.parse(data);
+                find_shims_in_package(data, cur_path, shims);
+                return cb(null, shims);
             }
             catch (err) {
-                err.message = pkg_path + ' : ' + err.message
                 return cb(err);
             }
+        });
+    })();
+};
 
-            // support legacy browserify field for easier migration from legacy
-            // many packages used this field historically
+// paths is mutated
+// synchronously load shims from first package.json file found
+function load_shims_sync(paths) {
+    // identify if our file should be replaced per the browser field
+    // original filename|id -> replacement
+    var shims = {};
+    var cur_path;
+
+    while (cur_path = paths.shift()) {
+        var pkg_path = path.join(cur_path, 'package.json');
+
+        try {
+            var data = fs.readFileSync(pkg_path, 'utf8');
+            find_shims_in_package(data, cur_path, shims);
+            return shims;
+        }
+        catch (err) {
+            // ignore paths we can't open
+            // avoids an exists check
+            if (err.code === 'ENOENT') {
+                continue;
+            }
+
+            throw err;
+        }
+    }
+    return shims;
+}
+
+function build_resolve_opts(opts, base) {
+    return {
+        paths: opts.paths,
+        extensions: opts.extensions,
+        basedir: base,
+        package: opts.package,
+        packageFilter: function (info, pkgdir) {
+            if (opts.packageFilter) info = opts.packageFilter(info, pkgdir);
+
+            // support legacy browserify field
             if (typeof info.browserify === 'string' && !info.browser) {
                 info.browser = info.browserify;
             }
 
-            // no replacements, skip shims
+            // no browser field, keep info unchanged
             if (!info.browser) {
-                return cb(null, shims);
+                return info;
             }
 
-            // if browser field is a string
-            // then it just replaces the main entry point
+            // replace main
             if (typeof info.browser === 'string') {
-                var key = path.resolve(cur_path, info.main || 'index.js');
-                shims[key] = path.resolve(cur_path, info.browser);
-                return cb(null, shims);
+                info.main = info.browser;
+                return info;
             }
 
-            // http://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders
-            Object.keys(info.browser).forEach(function(key) {
-                if (info.browser[key] === false) {
-                    return shims[key] = __dirname + '/empty.js';
-                }
+            var replace_main = info.browser[info.main || './index.js'] ||
+                info.browser['./' + info.main || './index.js'];
 
-                var val = info.browser[key];
-
-                // if target is a relative path, then resolve
-                // otherwise we assume target is a module
-                if (val[0] === '.') {
-                    val = path.resolve(cur_path, val);
-                }
-
-                // if does not begin with / ../ or ./ then it is a module
-                if (key[0] !== '/' && key[0] !== '.') {
-                    return shims[key] = val;
-                }
-
-                var key = path.resolve(cur_path, key);
-                shims[key] = val;
-            });
-            return cb(null, shims);
-        });
-    })();
-};
+            info.main = replace_main || info.main;
+            return info;
+        }
+    };
+}
 
 function resolve(id, opts, cb) {
 
@@ -149,37 +220,7 @@ function resolve(id, opts, cb) {
 
         // our browser field resolver
         // if browser field is an object tho?
-        var full = resv(id, {
-            paths: opts.paths,
-            extensions: opts.extensions,
-            basedir: base,
-            package: opts.package,
-            packageFilter: function(info, pkgdir) {
-                if (opts.packageFilter) info = opts.packageFilter(info, pkgdir);
-
-                // support legacy browserify field
-                if (typeof info.browserify === 'string' && !info.browser) {
-                    info.browser = info.browserify;
-                }
-
-                // no browser field, keep info unchanged
-                if (!info.browser) {
-                    return info;
-                }
-
-                // replace main
-                if (typeof info.browser === 'string') {
-                    info.main = info.browser;
-                    return info;
-                }
-
-                var replace_main = info.browser[info.main || './index.js'] ||
-                                   info.browser['./' + info.main || './index.js'];
-
-                info.main = replace_main || info.main;
-                return info;
-            }
-        }, function(err, full, pkg) {
+        var full = resv(id, build_resolve_opts(opts, base), function(err, full, pkg) {
             if (err) {
                 return cb(err);
             }
@@ -188,6 +229,52 @@ function resolve(id, opts, cb) {
             cb(null, resolved, pkg);
         });
     });
+};
+
+resolve.sync = function (id, opts) {
+
+    // opts.filename
+    // opts.paths
+    // opts.modules
+    // opts.packageFilter
+
+    opts = opts || {};
+
+    var base = path.dirname(opts.filename);
+    var paths = nodeModulesPaths(base);
+
+    if (opts.paths) {
+        paths.push.apply(paths, opts.paths);
+    }
+
+    paths = paths.map(function(p) {
+        return path.dirname(p);
+    });
+
+    // we must always load shims because the browser field could shim out a module
+    var shims = load_shims_sync(paths);
+
+    if (shims[id]) {
+        // if the shim was is an absolute path, it was fully resolved
+        if (shims[id][0] === '/') {
+            return shims[id];
+        }
+
+        // module -> alt-module shims
+        id = shims[id];
+    }
+
+    var modules = opts.modules || {};
+    var shim_path = modules[id];
+    if (shim_path) {
+        return shim_path;
+    }
+
+    // our browser field resolver
+    // if browser field is an object tho?
+    var full = resv.sync(id, build_resolve_opts(opts, base));
+
+    return (shims) ? shims[full] || full : full;
 };
 
 module.exports = resolve;

--- a/test/core-sync.js
+++ b/test/core-sync.js
@@ -1,0 +1,17 @@
+// test loading core modules
+var assert = require('assert');
+var resolve = require('../');
+
+var shims = {
+    events: 'foo'
+};
+
+test('shim found', function() {
+    var path = resolve.sync('events', { modules: shims });
+    assert.equal(path, 'foo');
+});
+
+test('core shim not found', function() {
+    var path = resolve.sync('http', {});
+    assert.equal(path, 'http');
+});

--- a/test/false-sync.js
+++ b/test/false-sync.js
@@ -1,0 +1,17 @@
+var assert = require('assert');
+var path = require('path');
+var resolve = require('../');
+
+var fixtures_dir = __dirname + '/fixtures';
+
+test('false file', function() {
+    var parent_file = fixtures_dir + '/node_modules/false/index.js';
+    var p = resolve.sync('./fake.js', { filename: parent_file });
+    assert.equal(p, path.normalize(__dirname + '/../empty.js'));
+});
+
+test('false module', function() {
+    var parent_file = fixtures_dir + '/node_modules/false/index.js';
+    var p = resolve.sync('ignore-me', { filename: parent_file });
+    assert.equal(p, path.normalize(__dirname + '/../empty.js'));
+});

--- a/test/local-sync.js
+++ b/test/local-sync.js
@@ -1,0 +1,12 @@
+var assert = require('assert');
+var resolve = require('../');
+
+var fixtures_dir = __dirname + '/fixtures';
+
+test('local', function() {
+    // resolve needs a parent filename or paths to be able to lookup files
+    // we provide a phony parent file
+    var path = resolve.sync('./foo', { filename: fixtures_dir + '/phony.js' });
+    assert.equal(path, require.resolve('./fixtures/foo'));
+});
+

--- a/test/modules-sync.js
+++ b/test/modules-sync.js
@@ -1,0 +1,139 @@
+var assert = require('assert');
+var resolve = require('../');
+
+var fixtures_dir = __dirname + '/fixtures/node_modules';
+
+// no package.json, load index.js
+test('index.js of module dir', function() {
+    var path = resolve.sync('module-a', { paths: [ fixtures_dir ], package: { main: 'fixtures' } });
+    assert.equal(path, require.resolve('./fixtures/node_modules/module-a/index'));
+});
+
+// package.json main field specifies other location
+test('alternate main', function() {
+    var path = resolve.sync('module-b', { paths: [ fixtures_dir ], package: { main: 'fixtures' } });
+    assert.equal(path, require.resolve('./fixtures/node_modules/module-b/main'));
+});
+
+// package.json has 'browser' field which is a string
+test('string browser field as main', function() {
+    var path = resolve.sync('module-c', { paths: [ fixtures_dir ], package: { main: 'fixtures' } });
+    assert.equal(path, require.resolve('./fixtures/node_modules/module-c/browser'));
+});
+
+// package.json has 'browser' field which is a string
+test('string browser field as main - require subfile', function() {
+    var parent = {
+        filename: fixtures_dir + '/module-c/browser.js',
+        paths: [ fixtures_dir + '/module-c/node_modules' ],
+        package: { main: './browser.js' }
+    };
+
+    var path = resolve.sync('./bar', parent);
+    assert.equal(path, require.resolve('./fixtures/node_modules/module-c/bar'));
+});
+
+// package.json has browser field as object
+// one of the keys replaces the main file
+// this would be done if the user needed to replace main and some other module
+test('object browser field as main', function() {
+    var path = resolve.sync('module-d', { paths: [ fixtures_dir ], package: { main: 'fixtures' } });
+    assert.equal(path, require.resolve('./fixtures/node_modules/module-d/browser'));
+});
+
+// package.json has browser field as object
+// one of the keys replaces the main file
+// however the main has no prefix and browser uses ./ prefix for the same file
+test('object browser field as main', function() {
+    var path = resolve.sync('module-k', { paths: [ fixtures_dir ], package: { main: 'fixtures' } });
+    assert.equal(path, require.resolve('./fixtures/node_modules/module-k/browser'));
+});
+
+// browser field in package.json maps ./foo.js -> ./browser.js
+// when we resolve ./foo while in module-e, this mapping should take effect
+// the result is that ./foo resolves to ./browser
+test('object browser field replace file', function() {
+    var parent = {
+        filename: fixtures_dir + '/module-e/main.js',
+        package: { main: './main.js' }
+    };
+
+    var path = resolve.sync('./foo', parent);
+    assert.equal(path, require.resolve('./fixtures/node_modules/module-e/browser'));
+});
+
+// browser field in package.json maps "module" -> "alternate module"
+test('test foobar -> module-b replacement', function() {
+    var parent = {
+        filename: fixtures_dir + '/module-h/index.js',
+        package: { main: './index.js' }
+    };
+
+    var path = resolve.sync('foobar', parent);
+    assert.equal(path, require.resolve('./fixtures/node_modules/module-b/main'));
+});
+
+// same as above but replacing core
+test('test core -> module-c replacement', function() {
+    var parent = {
+        filename: fixtures_dir + '/module-h/index.js',
+        package: { main: './index.js' }
+    };
+
+    var path = resolve.sync('querystring', parent);
+    assert.equal(path, require.resolve('./fixtures/node_modules/module-c/browser'));
+});
+
+// browser field in package.json maps "module" -> "alternate module"
+test('test foobar -> module-b replacement with transform', function() {
+    var parent = {
+        filename: fixtures_dir + '/module-i/index.js',
+        package: { main: './index.js' }
+    };
+
+    var path = resolve.sync('foobar', parent);
+    assert.equal(path, require.resolve('./fixtures/node_modules/module-b/main'));
+});
+
+test('test foobar -> module-i replacement with transform in replacement', function() {
+    var parent = {
+        filename: fixtures_dir + '/module-j/index.js',
+        package: { main: './index.js' }
+    };
+
+    var path = resolve.sync('foobar', parent);
+    assert.equal(path, require.resolve('./fixtures/node_modules/module-i/index'));
+});
+
+// same as above, but without a paths field in parent
+// should still checks paths on the filename of parent
+test('object browser field replace file - no paths', function() {
+    var parent = {
+        filename: fixtures_dir + '/module-f/lib/main.js',
+        package: { main: './lib/main.js' }
+    };
+
+    var path = resolve.sync('./foo', parent);
+    assert.equal(path, require.resolve('./fixtures/node_modules/module-f/lib/browser'));
+});
+
+test('replace module in browser field object', function() {
+    var parent = {
+        filename: fixtures_dir + '/module-g/index.js',
+        package: { main: './index.js' }
+    };
+
+    var path = resolve.sync('foobar', parent);
+    assert.equal(path, require.resolve('./fixtures/node_modules/module-g/foobar-browser'));
+});
+
+test('override engine shim', function() {
+    var parent = {
+        filename: fixtures_dir + '/override-engine-shim/index.js',
+        package: { main: './index.js' },
+        modules: { url: "wonderland" }
+    };
+    var path = resolve.sync('url', parent);
+    assert.equal(path, require.resolve('./fixtures/node_modules/override-engine-shim/url-browser'));
+});
+


### PR DESCRIPTION
To keep code duplication down, I factored out the low-hanging fruit (the `find_shims_in_package` and `build_resolve_opts` functions) but I didn't get very aggressive, so there's still a fair amount of repetition. Let me know if/what you want me to adjust.

For tests, I just followed the lead of the -coffee variants and copied the test files with a -sync suffix. Mocha's output is a bit redundant, of course, so if one test were to fail it might prove difficult to find out which one it is, but I didn't want to go ahead and wrap everything in `suite()` blocks without asking you first.

One thing the sync api can't do is return the package object, which appears to be an undocumented feature of both this module and `resolve`, so I figure it's not a big deal. Particularly since it's not returned by `resolve.sync`.

Sorry about the messy diff — the big blocks are mostly unchanged, just code extracted into functions.
