### PR TITLE
Pass through original `opts` properties to resolve

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,37 +143,36 @@ function load_shims_sync(paths) {
 }
 
 function build_resolve_opts(opts, base) {
-    return {
-        paths: opts.paths,
-        extensions: opts.extensions,
-        basedir: base,
-        package: opts.package,
-        packageFilter: function (info, pkgdir) {
-            if (opts.packageFilter) info = opts.packageFilter(info, pkgdir);
+    var packageFilter = opts.packageFilter;
 
-            // support legacy browserify field
-            if (typeof info.browserify === 'string' && !info.browser) {
-                info.browser = info.browserify;
-            }
+    opts.basedir = base;
+    opts.packageFilter = function (info, pkgdir) {
+        if (packageFilter) info = packageFilter(info, pkgdir);
 
-            // no browser field, keep info unchanged
-            if (!info.browser) {
-                return info;
-            }
+        // support legacy browserify field
+        if (typeof info.browserify === 'string' && !info.browser) {
+            info.browser = info.browserify;
+        }
 
-            // replace main
-            if (typeof info.browser === 'string') {
-                info.main = info.browser;
-                return info;
-            }
-
-            var replace_main = info.browser[info.main || './index.js'] ||
-                info.browser['./' + info.main || './index.js'];
-
-            info.main = replace_main || info.main;
+        // no browser field, keep info unchanged
+        if (!info.browser) {
             return info;
         }
+
+        // replace main
+        if (typeof info.browser === 'string') {
+            info.main = info.browser;
+            return info;
+        }
+
+        var replace_main = info.browser[info.main || './index.js'] ||
+            info.browser['./' + info.main || './index.js'];
+
+        info.main = replace_main || info.main;
+        return info;
     };
+
+    return opts;
 }
 
 function resolve(id, opts, cb) {


### PR DESCRIPTION
The purpose of this module is to augment the functionality of [resolve](https://github.com/substack/node-resolve), correct? I propose that in `build_resolve_opts()` instead of replacing `opts` and blowing away some of its properties, augment it as necessary so that its other original properties are available to resolve.

This will, for example, facilitate generation of useful `Cannot find module` error messages in resolve. Currently if using browserify and you have 100 files in a directory and one of them generates a `Cannot find module` error, the error message doesn't tell you which file was the source of the error.

I recommend comparing this with `git diff -b` to get an overview of the actual changes with less noise.