### PR TITLE
Gets a basic deep module reference test working with 1.1.0 node-resolve

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,6 +171,31 @@ function build_resolve_opts(opts, base) {
         info.main = replace_main || info.main;
         return info;
     };
+    
+    var pathFilter = opts.pathFilter;
+    opts.pathFilter = function(info, path, relativePath) {
+    	if(relativePath[0] != '.') {
+    		relativePath = './' + relativePath;
+    	}
+    	var mappedPath;
+    	if(pathFilter) {
+    		mappedPath = pathFilter.apply(this, arguments);
+    	}
+    	if(mappedPath) {
+    		return mappedPath;
+    	}
+    	if(!info.browser) {
+    		return;
+    	}
+    	
+    	if(typeof info.browser) {
+    		mappedPath = info.browser[relativePath];
+    		if(!mappedPath && (relativePath.lastIndexOf(".js") === relativePath.length-3) ) {
+    			mappedPath = info.browser[relativePath+".js"];
+    		}
+    		return mappedPath;
+    	}
+    };
 
     return opts;
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Roman Shtylman <shtylman@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "resolve": "1.0.0"
+    "resolve": "1.1.0"
   },
   "devDependencies": {
     "mocha": "1.14.0"

--- a/test/fixtures/node_modules/module-l/browser.js
+++ b/test/fixtures/node_modules/module-l/browser.js
@@ -1,0 +1,1 @@
+// browser entry file

--- a/test/fixtures/node_modules/module-l/index.js
+++ b/test/fixtures/node_modules/module-l/index.js
@@ -1,0 +1,1 @@
+// node empty file

--- a/test/fixtures/node_modules/module-l/package.json
+++ b/test/fixtures/node_modules/module-l/package.json
@@ -1,0 +1,7 @@
+{
+    "main": "index.js",
+    "browser": {
+        "./index.js": "./browser.js",
+        "./direct": "./browser-direct.js"
+    }
+}

--- a/test/modules.js
+++ b/test/modules.js
@@ -73,6 +73,15 @@ test('object browser field as main', function(done) {
     });
 });
 
+test('deep module reference mapping', function(done) {
+    resolve('module-l/direct', { basedir: __dirname + '/fixtures', package: { main: 'fixtures' } }, function(err, path, pkg) {
+        assert.ifError(err);
+        assert.equal(path, require.resolve('./fixtures/node_modules/module-l/browser-direct'));
+        assert.equal(pkg.main, './browser.js');
+        done();
+    });
+});
+
 // browser field in package.json maps ./foo.js -> ./browser.js
 // when we resolve ./foo while in module-e, this mapping should take effect
 // the result is that ./foo resolves to ./browser
@@ -185,7 +194,7 @@ test('override engine shim', function(done) {
     var parent = {
         filename: fixtures_dir + '/override-engine-shim/index.js',
         package: { main: './index.js' },
-        modules: { url: "wonderland" }
+        modules: { url: 'wonderland' }
     };
     resolve('url', parent, function(err, path, pkg) {
         assert.ifError(err);


### PR DESCRIPTION
For #51, this uses the 1.1.0 node-resolve to make deep module references mappable.

It works by adding a pathFilter that checks `browser` for a matching key and returns that value.  It handles if the user does or does not end the map with `.js`.

It includes a test.

Thanks!