### PR TITLE
fall back to 'browser' in deps without alt-browser field

### DIFF
--- a/index.js
+++ b/index.js
@@ -312,7 +312,7 @@ function normalizeBrowserFieldName(browser) {
 
 function getReplacements(info, browser) {
     browser = normalizeBrowserFieldName(browser);
-    var replacements = info[browser];
+    var replacements = info[browser] || info.browser;
 
     // support legacy browserify field for easier migration from legacy
     // many packages used this field historically

--- a/test/fixtures/node_modules/alt-browser-field/foo.js
+++ b/test/fixtures/node_modules/alt-browser-field/foo.js
@@ -1,0 +1,1 @@
+ require('foobar');

--- a/test/fixtures/node_modules/alt-browser-field/package.json
+++ b/test/fixtures/node_modules/alt-browser-field/package.json
@@ -6,6 +6,7 @@
     "chromeapp": {
         "url": "./url-chromeapp.js",
         "./index.js": "./chromeapp.js",
-        "./direct": "./chromeapp-direct.js"
+        "./direct": "./chromeapp-direct.js",
+        "foobar": "module-k"
     }
 }

--- a/test/modules.js
+++ b/test/modules.js
@@ -263,3 +263,19 @@ test('alt-browser deep module reference mapping', function(done) {
         done();
     });
 });
+
+test('alt-browser fallback to "browser" on deps of deps', function(done) {
+    var parent = {
+        filename: fixtures_dir + '/alt-browser-field/foo.js',
+        package: { main: './index.js' },
+        browser: 'chromeapp'
+    };
+
+    resolve('foobar', parent, function(err, path, pkg) {
+        assert.ifError(err);
+        assert.equal(path, require.resolve('./fixtures/node_modules/module-k/browser'));
+        assert.equal(pkg.main, './browser.js');
+        assert.equal(pkg.browser['./index.js'], './browser.js');
+        done();
+    });
+});


### PR DESCRIPTION
see scenario in https://github.com/defunctzombie/node-browser-resolve/issues/62 or added test

without the fallback, it'll choke as soon as it hits a nested browserifiable package without an alt browser field. This is kind of a step back to thinking of the "browser" field as a default, and an alt-browser field as an override
