### PR TITLE
Fix Node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
     - "0.8"
     - "0.10"
+    - "4"
+    - "5"
+    - "6"

--- a/index.js
+++ b/index.js
@@ -214,6 +214,7 @@ function resolve(id, opts, cb) {
     // opts.packageFilter
 
     opts = opts || {};
+    opts.filename = opts.filename || '';
 
     var base = path.dirname(opts.filename);
 
@@ -278,6 +279,8 @@ resolve.sync = function (id, opts) {
     // opts.packageFilter
 
     opts = opts || {};
+    opts.filename = opts.filename || '';
+
     var base = path.dirname(opts.filename);
 
     if (opts.basedir) {


### PR DESCRIPTION
Latest Node is more strict with `path.dirname`, throwing on passing undefined - https://github.com/nodejs/node/pull/5348

Also added newer Node versions to Travis test matrix.